### PR TITLE
Update Makefile - PLUGIN_DEPENDS needs hiredis

### DIFF
--- a/nprobe/plugins/net/nprobe/Makefile
+++ b/nprobe/plugins/net/nprobe/Makefile
@@ -1,7 +1,7 @@
 PLUGIN_NAME=		nprobe
 PLUGIN_VERSION=		1.0
 PLUGIN_COMMENT=		NetFlow/IPFIX probe and collector
-PLUGIN_DEPENDS=		nprobe
+PLUGIN_DEPENDS=		nprobe hiredis
 PLUGIN_MAINTAINER=	packager@ntop.org
 
 .include "../../Mk/plugins.mk"


### PR DESCRIPTION
When installing os-nprobe on opnsense it doesn't start cause of missing libhiredis.so.
You can force the installation of the required packages via PLUGIN_DEPENDS which make it work on my install.