### PR TITLE
Put daemon mode into nprobe.conf

### DIFF
--- a/nprobe/plugins/net/nprobe/src/opnsense/service/templates/OPNsense/nProbe/nprobe.conf
+++ b/nprobe/plugins/net/nprobe/src/opnsense/service/templates/OPNsense/nProbe/nprobe.conf
@@ -11,6 +11,7 @@
 {%   endif %}
 -n=none
 -T="@NTOPNG@"
+-G
 {%   if helpers.exists('OPNsense.nprobe.general.ipsmode') and OPNsense.nprobe.general.ipsmode == '1' %}
 --ips-mode=/usr/local/etc/nprobe-ips.conf
 {%     if helpers.exists('OPNsense.nprobe.general.ips_events') and OPNsense.nprobe.general.ips_events == '1' %}


### PR DESCRIPTION
This is needed to run in backgound mode. When starting nprobe via UI it takes 2 minutes to start (spinning wheel) which will run into 120sec timeout counter from configd itself because in reality it runs in foreground. 

With this setup daemon is started within couple of moments.